### PR TITLE
import PIL.Image (just PIL has no attribute image imported)

### DIFF
--- a/ascii/ascii_convert.py
+++ b/ascii/ascii_convert.py
@@ -1,4 +1,5 @@
 import PIL
+import PIL.Image
 
 # ascii characters used to build the output text
 ASCII_CHARS = ["@", "#", "S", "%", "?", "*", "+", ";", ":", ",", "."]


### PR DESCRIPTION
Hello,
This is the first merge I ever do so feel free to refuse it if it doesn't fit your needs.
I tried using your code to convert an image to an ascii art but kept having the except block execute. According to stack Overflow it has to do with the __init__.py of PIL no longer importing PIL.Image by default.
Therefore I added the import PIL.Image line and then the program worked !
(Python 3.8.1 on Windows 10)